### PR TITLE
some fixes

### DIFF
--- a/include/tvm/runtime/vm.h
+++ b/include/tvm/runtime/vm.h
@@ -270,6 +270,7 @@ struct Instruction {
   /*!
    * \brief Construct an allocate tensor instruction with constant shape.
    * \param storage The storage to allocate out of.
+   * \param offset The offset into the storage to allocate from.
    * \param shape The shape of the tensor.
    * \param dtype The dtype of the tensor.
    * \param dst The destination register.

--- a/python/tvm/relay/transform/memory_alloc.py
+++ b/python/tvm/relay/transform/memory_alloc.py
@@ -174,7 +174,7 @@ class ManifestAllocPass(ExprMutator):
             size = self.compute_storage_in_relay(
                 out_shape, out_type.dtype)
             alignment = self.compute_alignment(out_type.dtype)
-            sto = scope.let("storage_{i}".format(i=i), self.alloc_storage(
+            sto = scope.let("storage_{i}".format(i=i), alloc_storage(
                 size, alignment, self.default_context, out_type.dtype))
             storages.append(sto)
 

--- a/src/relay/backend/vm/compiler.cc
+++ b/src/relay/backend/vm/compiler.cc
@@ -906,8 +906,6 @@ transform::Sequential MemoryOpt(tvm::Target host_target) {
 
   // Perform memory planning in order to coalesce/reduce allocations.
   pass_seqs.push_back(transform::MemoryPlan());
-  // Compute away possibly introduced constant computation.
-  pass_seqs.push_back(transform::FoldConstant());
 
   return transform::Sequential(pass_seqs);
 }
@@ -965,8 +963,7 @@ IRModule VMCompiler::OptimizeModule(const IRModule& mod, const TargetsMap& targe
   pass_seqs.push_back(transform::LambdaLift());
   pass_seqs.push_back(transform::InlinePrimitives());
 
-
-
+  // Memory optimization
   pass_seqs.push_back(MemoryOpt(this->target_host_));
 
   transform::Sequential seq(pass_seqs);

--- a/src/runtime/vm/executable.cc
+++ b/src/runtime/vm/executable.cc
@@ -314,7 +314,7 @@ VMInstructionSerializer SerializeInstruction(const Instruction& instr) {
       break;
     }
     case Opcode::AllocTensor: {
-      // Number of fields = 6 + instr.alloc_tensor.ndim
+      // Number of fields = 7 + instr.alloc_tensor.ndim
       fields.push_back(instr.alloc_tensor.storage);
       fields.push_back(instr.alloc_tensor.offset);
       // Save `DLDataType` and the dst register.
@@ -565,7 +565,7 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       return Instruction::InvokePacked(packed_index, arity, output_size, args);
     }
     case Opcode::AllocTensor: {
-      // Number of fields = 6 + instr.alloc_tensor.ndim
+      // Number of fields = 7 + instr.alloc_tensor.ndim
       DCHECK_GE(instr.fields.size(), 7U);
       DCHECK_EQ(instr.fields.size(), 7U + static_cast<size_t>(instr.fields[4]));
 
@@ -580,7 +580,7 @@ Instruction DeserializeInstruction(const VMInstructionSerializer& instr) {
       Index ndim = instr.fields[5];
       RegName dst = instr.fields[6];
 
-      std::vector<Index> shape = ExtractFields(instr.fields, 6, ndim);
+      std::vector<Index> shape = ExtractFields(instr.fields, 7, ndim);
 
       return Instruction::AllocTensor(storage_reg, offset, shape, dtype, dst);
     }


### PR DESCRIPTION
Some fixes. I tested it locally test_vm and test_vm_serialization can all pass. CI should be happy now. Two other fixes. The first one is the serialization.

In the second one, I removed the last constant folding pass in memory pass to make test_vm_serialization pass (like MobileNet and ResNet). It actually reveals a problem/bug for VM because with this constant folding we will have:

```
let %1 = fn(p0, p1) {
  add(p0, p1)
}
%2 = (constant_1, constant_2)
%3 = (tensor1,)
invoke_tvm_op(%1, %2, %3)
```
Then compiler would get stuck here:

https://github.com/apache/incubator-tvm/blob/c936a81dab2b4b4b595d02153a6654b9d4e09cd5/src/relay/backend/vm/compiler.cc#L463

The problem reported by Luis is actually the same, which actually wasn't a bug introduced by the mentioned PR, but it would reveal this problem.
