### PR TITLE
Initial shot at structural equal and bug fixes in cpp_generator.py

### DIFF
--- a/objectgen/objectgen/cpp_generator.py
+++ b/objectgen/objectgen/cpp_generator.py
@@ -196,7 +196,7 @@ class CPPGenerator(Generator):
                     else:
                         equal_method = "equal"
 
-                    header_buf.write(f" #{equal_method}({field.field_name}, other->{field.field_name})")
+                    header_buf.write(f" {equal_method}({field.field_name}, other->{field.field_name})")
                     if i != len(object_def.fields) - 1:
                         header_buf.write(" && ")
         else:

--- a/objectgen/objectgen/cpp_generator.py
+++ b/objectgen/objectgen/cpp_generator.py
@@ -183,14 +183,14 @@ class CPPGenerator(Generator):
         header_buf.write(f"{4 * ' '}bool SEqualReduce(const {object_def.payload_name()}* other, SEqualReducer equal) const {{\n")
         header_buf.write(f"{8 * ' '}return")
 
-        check_equal_fields = [f for f in object_def.fields if f.check_equality]
+        check_equal_fields = [f for f in object_def.fields if f.use_in_sequal_reduce]
         if len(check_equal_fields):
             has_bindings = any([f.is_binding for f in check_equal_fields])
             if has_bindings:
                 raise Exception("add MarkNodeGraph")
 
             for i, field in enumerate(check_equal_fields):
-                if field.check_equality:  # Whether this field should be included in the structural equality
+                if field.use_in_sequal_reduce:  # Whether this field should be included in the structural equality
                     if has_bindings and field.is_binding:
                         equal_method = "DefEqual"
                     else:

--- a/objectgen/objectgen/cpp_generator.py
+++ b/objectgen/objectgen/cpp_generator.py
@@ -197,7 +197,7 @@ class CPPGenerator(Generator):
                         equal_method = "equal"
 
                     header_buf.write(f" {equal_method}({field.field_name}, other->{field.field_name})")
-                    if i != len(object_def.fields) - 1:
+                    if i != len(check_equal_fields) - 1:
                         header_buf.write(" && ")
         else:
             header_buf.write(" true")

--- a/objectgen/objectgen/cpp_generator.py
+++ b/objectgen/objectgen/cpp_generator.py
@@ -183,21 +183,22 @@ class CPPGenerator(Generator):
         header_buf.write(f"{4 * ' '}bool SEqualReduce(const {object_def.payload_name()}* other, SEqualReducer equal) const {{\n")
         header_buf.write(f"{8 * ' '}return")
 
-        if len(object_def.fields):
-            has_bindings = any([f.is_binding for f in object_def.fields])
-
+        check_equal_fields = [f for f in object_def.fields if f.check_equality]
+        if len(check_equal_fields):
+            has_bindings = any([f.is_binding for f in check_equal_fields])
             if has_bindings:
                 raise Exception("add MarkNodeGraph")
 
-            for i, field in enumerate(object_def.fields):
-                if has_bindings and field.is_binding:
-                    equal_method = "DefEqual"
-                else:
-                    equal_method = "equal"
+            for i, field in enumerate(check_equal_fields):
+                if field.check_equality:  # Whether this field should be included in the structural equality
+                    if has_bindings and field.is_binding:
+                        equal_method = "DefEqual"
+                    else:
+                        equal_method = "equal"
 
-                header_buf.write(f" #{equal_method}({field.field_name}, other->{field.field_name})")
-                if i != len(object_def.fields) - 1:
-                    header_buf.write(" && ")
+                    header_buf.write(f" #{equal_method}({field.field_name}, other->{field.field_name})")
+                    if i != len(object_def.fields) - 1:
+                        header_buf.write(" && ")
         else:
             header_buf.write(" true")
 

--- a/objectgen/objectgen/object_def.py
+++ b/objectgen/objectgen/object_def.py
@@ -15,7 +15,7 @@ class ObjectField:
     field_name: str
     field_type: Type
     is_binding: bool = False
-    check_equality: bool = True
+    use_in_sequal_reduce: bool = True
 
 @attr.s
 class ObjectMethod:

--- a/objectgen/objectgen/object_def.py
+++ b/objectgen/objectgen/object_def.py
@@ -15,6 +15,7 @@ class ObjectField:
     field_name: str
     field_type: Type
     is_binding: bool = False
+    check_equality: bool = True
 
 @attr.s
 class ObjectMethod:

--- a/objectgen/relax.py
+++ b/objectgen/relax.py
@@ -26,14 +26,14 @@ relax_expr = in_ns(["relax", "expr"], relax_expr_imports, [
     ObjectDefinition(
         name="Type",
         fields=[
-            ObjectField("span", "Span")
+            ObjectField("span", "Span", check_equality=False)
         ],
         final = False,
     ),
     ObjectDefinition(
         name="Expr",
         fields=[
-            ObjectField("span", "Span")
+            ObjectField("span", "Span", check_equality=False)
         ],
         final = False,
     ),
@@ -87,7 +87,7 @@ relax_expr = in_ns(["relax", "expr"], relax_expr_imports, [
         name="Function",
         inherits_from="Expr",
         fields=[
-            ObjectField("name", "Optional<runtime::String>"),
+            ObjectField("name", "Optional<runtime::String>", check_equality=False),
             ObjectField("params", "runtime::Array<Var>"),
             ObjectField("body", "Expr"),
             ObjectField("ret_type", "Type"),
@@ -189,7 +189,7 @@ relax_vm = in_ns(["relax", "vm"], relax_vm_imports, [
     ObjectDefinition(
         name="Instruction",
         fields=[
-            ObjectField("span", "Span")
+            ObjectField("span", "Span", check_equality=False)
         ],
         final = False,
     ),

--- a/objectgen/relax.py
+++ b/objectgen/relax.py
@@ -26,14 +26,14 @@ relax_expr = in_ns(["relax", "expr"], relax_expr_imports, [
     ObjectDefinition(
         name="Type",
         fields=[
-            ObjectField("span", "Span", check_equality=False)
+            ObjectField("span", "Span", use_in_sequal_reduce=False)
         ],
         final = False,
     ),
     ObjectDefinition(
         name="Expr",
         fields=[
-            ObjectField("span", "Span", check_equality=False)
+            ObjectField("span", "Span", use_in_sequal_reduce=False)
         ],
         final = False,
     ),
@@ -87,7 +87,7 @@ relax_expr = in_ns(["relax", "expr"], relax_expr_imports, [
         name="Function",
         inherits_from="Expr",
         fields=[
-            ObjectField("name", "Optional<runtime::String>", check_equality=False),
+            ObjectField("name", "Optional<runtime::String>", use_in_sequal_reduce=False),
             ObjectField("params", "runtime::Array<Var>"),
             ObjectField("body", "Expr"),
             ObjectField("ret_type", "Type"),
@@ -189,7 +189,7 @@ relax_vm = in_ns(["relax", "vm"], relax_vm_imports, [
     ObjectDefinition(
         name="Instruction",
         fields=[
-            ObjectField("span", "Span", check_equality=False)
+            ObjectField("span", "Span", use_in_sequal_reduce=False)
         ],
         final = False,
     ),

--- a/python/tvm/relax/frontend.py
+++ b/python/tvm/relax/frontend.py
@@ -15,6 +15,7 @@ import numpy as np
 import synr
 from synr import ast, Transformer
 from synr.diagnostic_context import DiagnosticContext
+from tvm.script.utils import tvm_span_from_synr, synr_span_from_tvm
 
 from .compile import Compiler
 
@@ -51,11 +52,6 @@ class R2Transformer(Transformer): # Transformer[Module, relax.Function, relax.Ex
         self.module = {}
         super().__init__()
 
-    def span_to_span(self, span):
-        src_name = self.diag_ctx.str_to_source_name[span.filename]
-        tvm_span = tvm.ir.Span(src_name, span.start_line, span.end_line, span.start_column, span.end_column)
-        return tvm_span
-
     def decl_var(self, name, ty, span=None):
         identifier = Id(name)
         var = expr.Var(identifier, ty, span)
@@ -68,7 +64,7 @@ class R2Transformer(Transformer): # Transformer[Module, relax.Function, relax.Ex
 
         if isinstance(ty, ast.TypeVar):
             if ty.id.name == "Tensor":
-                span = self.span_to_span(ty.span)
+                span = tvm_span_from_synr(ty.span)
                 return expr.Tensor(None, None, span)
 
         if isinstance(ty, ast.TypeApply):
@@ -84,7 +80,7 @@ class R2Transformer(Transformer): # Transformer[Module, relax.Function, relax.Ex
 
         # import pdb; pdb.set_trace()
 
-        self._diagnostic_context.emit('error', "invalid type", self.span_to_span(ty.span))
+        self._diagnostic_context.emit('error', "invalid type", tvm_span_from_synr(ty.span))
         self._diagnostic_context.render()
 
     def transform_module(self, mod: ast.Module) -> Dict[str, relax.Function]:
@@ -226,7 +222,7 @@ class TVMDiagnosticContext(synr.DiagnosticContext):
         src_name = self.tvm_diag_ctx.module.source_map.add(name, source)
         self.str_to_source_name[name] = src_name
 
-    def emit(self, level: str, message: str, span: Span) -> None:
+    def emit(self, level: str, message: str, span: tvm.ir.Span) -> None:
         """Called when an error has occured."""
 
         if level == "error":
@@ -239,6 +235,7 @@ class TVMDiagnosticContext(synr.DiagnosticContext):
             level = "error"
 
         assert span, "Span must not be null"
+        assert isinstance(span, tvm.ir.span), "Expected tvm.ir.span, but got " + str(type(span))
 
         diag = diagnostics.Diagnostic(level, span, message)
 

--- a/python/tvm/script/utils.py
+++ b/python/tvm/script/utils.py
@@ -100,6 +100,7 @@ def buffer_slice_to_region(
 
 def tvm_span_from_synr(span: synr.ast.Span) -> Span:
     """Convert a synr span to a TVM span"""
+    assert isinstance(span, synr.ast.Span), "Expected span to be synr.ast.Span, but got " + str(type(span))
     return Span(
         SourceName(span.filename),
         span.start_line,
@@ -111,6 +112,7 @@ def tvm_span_from_synr(span: synr.ast.Span) -> Span:
 
 def synr_span_from_tvm(span: Span) -> synr.ast.Span:
     """Convert a TVM span to a synr span"""
+    assert isinstance(span, synr.ast.Span), "Expected span to be tvm.ir.Span, but got " + str(type(span))
     return synr.ast.Span(
         span.source_name.name,
         span.line,

--- a/tests/python/relax/test_relax_roundtrip.py
+++ b/tests/python/relax/test_relax_roundtrip.py
@@ -1,0 +1,70 @@
+"""Roundtripping tests for Relay Next (Relax)"""
+from __future__ import annotations
+from os import X_OK
+import tvm
+from tvm.relay.base import Id
+import tvm.relax.op.operators
+from tvm.relax import expr, r2
+
+
+from typing import TypeVar, Generic, Union
+from io import StringIO
+import numpy
+
+def assert_structural_equal(lhs, rhs, map_free_vars=False):
+    lhs = tvm.runtime.convert(lhs)
+    rhs = tvm.runtime.convert(rhs)
+    # These are packed funcs here
+    tvm.runtime._ffi_node_api.StructuralEqual(lhs, rhs, True, map_free_vars)
+
+@r2
+def foo(x: Tensor) -> Tensor:
+    return x
+
+foo1 = foo
+
+@r2
+def same_as_foo(x: Tensor) -> Tensor:
+    return x
+
+@r2
+def not_foo(x: Tensor, y: Tensor) -> Tensor:
+    return x
+
+@r2
+def foo(y: Tensor) -> Tensor:
+    return y
+
+foo2 = foo
+
+
+# test literally the same object
+def test_same():
+    rlx_program = foo
+    assert_structural_equal(rlx_program.module['foo'], rlx_program.module['foo'])
+
+
+# test two fns with the same name but different objects, different variable names
+# problem with span
+def test_same_name():
+    assert_structural_equal(foo1.module['foo'], foo2.module['foo'], True)
+
+
+# test two functions that are the same with different names
+def test_same_as_foo():
+    rlx_program1 = foo
+    rlx_program2 = same_as_foo
+    assert_structural_equal(rlx_program1.module['foo'], rlx_program2.module['same_as_foo'], True)
+
+def test_not_foo():
+    rlx_program1 = foo
+    rlx_program2 = not_foo
+    assert_structural_equal(rlx_program1.module['foo'], rlx_program2.module['not_foo'], True)
+
+# Tests that should succeed
+test_same()
+test_same_name()
+test_same_as_foo()
+
+# Tests that should fail
+# test_not_foo()


### PR DESCRIPTION
I added a method to do structural equality and changed the way relax SEqualReduce methods are generated and also some basic structural equality tests

The structural equality method only works on functions not relax modules right now, since relax modules are just dictionaries right now (are we going to change the relax modules to be an object? if not then I can just loop through that dictionary in the assert_structural_equal method).